### PR TITLE
Fix issue with app start up causing integration tests to fail

### DIFF
--- a/tests/Storm.TechTask.Api.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/tests/Storm.TechTask.Api.IntegrationTests/CustomWebApplicationFactory.cs
@@ -56,7 +56,6 @@ namespace Storm.TechTask.Api.IntegrationTests
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             builder
-                .UseSolutionRelativeContentRoot("src/StormDotNet.Channel.Api")
                 .ConfigureServices(services =>
                 {
                     BaseEndpointFixture.DbContextFactory.ConfigureDbContextForApi(services);


### PR DESCRIPTION
Removes line of code that was causing an exception to be thrown in API startup that was causing integration test failures. Error generated was:

```
System.IO.DirectoryNotFoundException: c:\Development\github\storm-tech-test-dotnet\src\StormDotNet.TechTask.Api\
   at Microsoft.Extensions.FileProviders.PhysicalFileProvider..ctor(String root, ExclusionFilters filters)
   at Microsoft.Extensions.FileProviders.PhysicalFileProvider..ctor(String root)
   at Microsoft.AspNetCore.Hosting.BootstrapHostBuilder.RunDefaultCallbacks(ConfigurationManager configuration, HostBuilder innerBuilder)
   at Microsoft.AspNetCore.Builder.WebApplicationBuilder..ctor(WebApplicationOptions options, Action`1 configureDefaults)
   at Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder(String[] args)
   at Program.<Main>$(String[] args) in c:\Development\github\storm-tech-test-dotnet\src\Storm.TechTask.Api\Program.cs:line 13
```